### PR TITLE
Fixes a few bugs affecting the tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2182,6 +2182,12 @@
       "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
       "dev": true
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true
+    },
     "string_decoder": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
@@ -2195,12 +2201,6 @@
           "dev": true
         }
       }
-    },
-    "string-width": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true
     },
     "stringstream": {
       "version": "0.0.5",

--- a/src/download-manager.js
+++ b/src/download-manager.js
@@ -250,7 +250,8 @@ class DownloadManager {
 
               fse.copySync(
                 path.join(mountedPath, chromeOSXAppName),
-                path.join(installDir, 'chrome', release, chromeOSXAppName)
+                path.join(installDir, 'chrome', release, chromeOSXAppName),
+                {dereference: true}
               );
 
               dmg.unmount(mountedPath, (err) => {
@@ -267,7 +268,9 @@ class DownloadManager {
       }
     })
     .then((filePath) => {
-      return del(filePath, {force: true});
+      if (filePath) {
+        return del(filePath, {force: true});
+      }
     });
   }
 
@@ -375,7 +378,8 @@ class DownloadManager {
 
             fse.copySync(
               path.join(mountedPath, firefoxMacApp),
-              path.join(installDir, 'firefox', release, firefoxMacApp)
+              path.join(installDir, 'firefox', release, firefoxMacApp),
+              {dereference: true}
             );
 
             dmg.unmount(mountedPath, (err) => {
@@ -392,7 +396,9 @@ class DownloadManager {
       throw new Error('Unable to handle downloaded file: ', downloadUrl);
     })
     .then((filePath) => {
-      return del(filePath, {force: true});
+      if (filePath) {
+        return del(filePath, {force: true});
+      }
     });
   }
 
@@ -608,7 +614,9 @@ class DownloadManager {
       }
     })
     .then((filePath) => {
-      return del(filePath, {force: true});
+      if (filePath) {
+        return del(filePath, {force: true});
+      }
     });
   }
 }


### PR DESCRIPTION
This should fix #87, which is currently affecting the Travis tests as well: https://travis-ci.org/GoogleChrome/selenium-assistant/jobs/245527631#L315

It also fixes another issue that I noticed when testing, in which there were scenarios where `del()` was called without passing it a path, causing that to reject.