### PR TITLE
Forces headless mode for Chrome

### DIFF
--- a/src/webdriver-config/chrome.js
+++ b/src/webdriver-config/chrome.js
@@ -29,7 +29,8 @@ class ChromeConfig extends DriverConfig {
   constructor() {
     super(
       'chrome',
-      new seleniumChrome.Options(),
+      // See https://developers.google.com/web/updates/2017/04/headless-chrome
+      new seleniumChrome.Options().addArguments('--headless', '--disable-gpu'),
       'Google Chrome',
       'chromedriver'
     );


### PR DESCRIPTION
As discussed.

This seems to work, but it's entirely possible that this should be optional, or implemented in a different subclass of the Chrome config or something. Feel free to tell me I'm doing it wrong 😄 