### PR TITLE
Close and quit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ osx_image: xcode7.3
 
 node_js:
   - '6'
-  - '7'
+  - '8'
 env:
   global:
     - COVERALLS_PARALLEL=true

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "homepage": "https://github.com/GoogleChrome/selenium-assistant#readme",
   "devDependencies": {
     "chai": "^4.0.2",
-    "chromedriver": "^2.26.1",
+    "chromedriver": "^2.30.1",
     "coveralls": "^2.11.12",
     "eslint": "^3.12.1",
     "eslint-config-google": "^0.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -343,7 +343,8 @@ class SeleniumAssistant {
     return new Promise((resolve) => {
       quitTimeout = setTimeout(resolve, 2000);
 
-      driver.quit()
+      driver.close()
+      .then(() => driver.quit())
       .then(resolve, resolve);
     })
     .then(() => {

--- a/test/selenium-assistant.js
+++ b/test/selenium-assistant.js
@@ -162,10 +162,11 @@ describe('SeleniumAssistant', function() {
     this.timeout(3000);
 
     const killPromise = seleniumAssistant.killWebDriver({
+      close: () => {
+        return Promise.resolve();
+      },
       quit: () => {
-        return new Promise((resolve, reject) => {
-          resolve();
-        });
+        return Promise.resolve();
       },
     });
     (killPromise instanceof Promise).should.equal(true);
@@ -177,10 +178,11 @@ describe('SeleniumAssistant', function() {
     this.timeout(3000);
 
     const killPromise = seleniumAssistant.killWebDriver({
+      close: () => {
+        return Promise.resolve();
+      },
       quit: () => {
-        return new Promise((resolve, reject) => {
-          reject();
-        });
+        return Promise.reject();
       },
     });
     (killPromise instanceof Promise).should.equal(true);
@@ -192,6 +194,9 @@ describe('SeleniumAssistant', function() {
     this.timeout(5000);
 
     const killPromise = seleniumAssistant.killWebDriver({
+      close: () => {
+        return Promise.resolve();
+      },
       quit: () => {
         return new Promise((resolve, reject) => {});
       },


### PR DESCRIPTION
Firefox nightly wasn't closing browsers after tests - turns out close() does close the window so adding that to the killWebdriver help function.